### PR TITLE
Added new PFAPI Endpoints to documentation

### DIFF
--- a/publicationiq.json
+++ b/publicationiq.json
@@ -723,6 +723,132 @@
             "description": "OK, Title details for a given KBID",
             "schema": {
               "type": "object",
+              "x-examples": {
+                "Example 1": {
+                  "titleId": "string",
+                  "titleName": "string",
+                  "edition": "string",
+                  "description": "string",
+                  "peerReviewed": true,
+                  "publisherName": "string",
+                  "identifiersList": [
+                    {
+                      "id": "string",
+                      "source": "string",
+                      "type": 0,
+                      "subtype": 0
+                    }
+                  ],
+                  "subjectsList": [
+                    {
+                      "type": "string",
+                      "name": "string"
+                    }
+                  ],
+                  "titleCustom": true,
+                  "pubType": "string",
+                  "contributorsList": [
+                    {
+                      "type": "string",
+                      "contributor": "string",
+                      "displayOrder": 0
+                    }
+                  ],
+                  "customerResourcesList": [
+                    {
+                      "titleId": 0,
+                      "packageId": 0,
+                      "packageName": "string",
+                      "packageType": "string",
+                      "isPackageCustom": true,
+                      "vendorId": 0,
+                      "vendorName": "string",
+                      "locationId": 0,
+                      "isSelected": true,
+                      "isTokenNeeded": true,
+                      "managedCoverageList": [
+                        {
+                          "beginCoverage": "2003-01-01",
+                          "endCoverage": "2003-12-12"
+                        }
+                      ],
+                      "customCoverageList": [
+                        {
+                          "beginCoverage": "2003-01-01",
+                          "endCoverage": "2003-12-12"
+                        }
+                      ],
+                      "coverageStatement": "string",
+                      "managedEmbargoPeriod": {
+                        "embargoUnit": "string",
+                        "embargoValue": 0
+                      },
+                      "customEmbargoPeriod": {
+                        "embargoUnit": "string",
+                        "embargoValue": 0
+                      },
+                      "url": "string",
+                      "linkOutTargetUrl": "string",
+                      "vendorToken": {
+                        "factName": "string",
+                        "value": "string"
+                      },
+                      "packageToken": {
+                        "factName": "string",
+                        "value": "string"
+                      },
+                      "targetUrl": "string",
+                      "proxy": {
+                        "id": "string",
+                        "inherited": true,
+                        "proxyName": "string",
+                        "urlMask": "string"
+                      },
+                      "note": [
+                        {
+                          "id": 0,
+                          "custId": 0,
+                          "noteName": "string",
+                          "rank": 0,
+                          "noteText": "string",
+                          "showOnFlags": {},
+                          "iconUrl": "string",
+                          "iconId": 0,
+                          "altText": "string",
+                          "hoverText": "string",
+                          "linkUrl": "string"
+                        }
+                      ],
+                      "userDefinedFields": [
+                        {
+                          "id": 0,
+                          "label": "string",
+                          "value": "string",
+                          "displayOnPublicationFinder": true
+                        }
+                      ],
+                      "visibilityData": {
+                        "isHidden": true,
+                        "reason": "Hidden by Customer"
+                      },
+                      "customerId": 0
+                    }
+                  ],
+                  "duration": "string",
+                  "frequency": "string",
+                  "alternateTitleList": [
+                    {
+                      "alternateTitle": "string",
+                      "titleType": "string"
+                    }
+                  ],
+                  "imageLink": "string",
+                  "licenseTerms": {
+                    "enabled": false,
+                    "noteLabel": "string"
+                  }
+                }
+              },
               "properties": {
                 "titleId": {
                   "type": "string"
@@ -956,8 +1082,10 @@
                               "type": "string"
                             },
                             "showOnFlags": {
-                              "type": "object",
-                              "properties": {}
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
                             },
                             "iconUrl": {
                               "type": "string"
@@ -1048,131 +1176,363 @@
                     }
                   }
                 }
-              },
-              "x-examples": {
-                "Example 1": {
-                  "titleId": "string",
-                  "titleName": "string",
-                  "edition": "string",
-                  "description": "string",
-                  "peerReviewed": true,
-                  "publisherName": "string",
-                  "identifiersList": [
-                    {
-                      "id": "string",
-                      "source": "string",
-                      "type": 0,
-                      "subtype": 0
-                    }
-                  ],
-                  "subjectsList": [
-                    {
-                      "type": "string",
-                      "name": "string"
-                    }
-                  ],
-                  "titleCustom": true,
-                  "pubType": "string",
-                  "contributorsList": [
-                    {
-                      "type": "string",
-                      "contributor": "string",
-                      "displayOrder": 0
-                    }
-                  ],
-                  "customerResourcesList": [
-                    {
-                      "titleId": 0,
-                      "packageId": 0,
-                      "packageName": "string",
-                      "packageType": "string",
-                      "isPackageCustom": true,
-                      "vendorId": 0,
-                      "vendorName": "string",
-                      "locationId": 0,
-                      "isSelected": true,
-                      "isTokenNeeded": true,
-                      "managedCoverageList": [
-                        {
-                          "beginCoverage": "2003-01-01",
-                          "endCoverage": "2003-12-12"
-                        }
-                      ],
-                      "customCoverageList": [
-                        {
-                          "beginCoverage": "2003-01-01",
-                          "endCoverage": "2003-12-12"
-                        }
-                      ],
-                      "coverageStatement": "string",
-                      "managedEmbargoPeriod": {
-                        "embargoUnit": "string",
-                        "embargoValue": 0
-                      },
-                      "customEmbargoPeriod": {
-                        "embargoUnit": "string",
-                        "embargoValue": 0
-                      },
-                      "url": "string",
-                      "linkOutTargetUrl": "string",
-                      "vendorToken": {
-                        "factName": "string",
-                        "value": "string"
-                      },
-                      "packageToken": {
-                        "factName": "string",
-                        "value": "string"
-                      },
-                      "targetUrl": "string",
-                      "proxy": {
-                        "id": "string",
-                        "inherited": true,
-                        "proxyName": "string",
-                        "urlMask": "string"
-                      },
-                      "note": [
-                        {
-                          "id": 0,
-                          "custId": 0,
-                          "noteName": "string",
-                          "rank": 0,
-                          "noteText": "string",
-                          "showOnFlags": {},
-                          "iconUrl": "string",
-                          "iconId": 0,
-                          "altText": "string",
-                          "hoverText": "string",
-                          "linkUrl": "string"
-                        }
-                      ],
-                      "userDefinedFields": [
-                        {
-                          "id": 0,
-                          "label": "string",
-                          "value": "string",
-                          "displayOnPublicationFinder": true
-                        }
-                      ],
-                      "visibilityData": {
-                        "isHidden": true,
-                        "reason": "Hidden by Customer"
-                      },
-                      "customerId": 0
-                    }
-                  ],
-                  "duration": "string",
-                  "frequency": "string",
-                  "alternateTitleList": [
-                    {
-                      "alternateTitle": "string",
-                      "titleType": "string"
-                    }
-                  ],
-                  "imageLink": "string",
-                  "licenseTerms": {
-                    "enabled": false,
-                    "noteLabel": "string"
+              }
+            },
+            "examples": {
+              "Title details": {
+                "titleId": "640633",
+                "titleName": "Nature Communications",
+                "edition": "",
+                "peerReviewed": true,
+                "publisherName": "Nature Publishing Group",
+                "identifiersList": [
+                  {
+                    "id": "2041-1723",
+                    "source": "Online ISSN",
+                    "type": 0,
+                    "subtype": 2
+                  },
+                  {
+                    "id": "616939100",
+                    "source": "SPID",
+                    "type": 3,
+                    "subtype": 0
+                  },
+                  {
+                    "id": "720546",
+                    "source": "EJS JournalID",
+                    "type": 4,
+                    "subtype": 0
+                  },
+                  {
+                    "id": "BNLI",
+                    "source": "MID",
+                    "type": 8,
+                    "subtype": 0
+                  },
+                  {
+                    "id": "2553671-0",
+                    "source": "ZDB-ID",
+                    "type": 6,
+                    "subtype": 0
+                  },
+                  {
+                    "id": "101528555",
+                    "source": "MID",
+                    "type": 8,
+                    "subtype": 0
                   }
+                ],
+                "subjectsList": [
+                  {
+                    "type": "Library of Congress",
+                    "name": "Science"
+                  },
+                  {
+                    "type": "Medical",
+                    "name": "Sciences"
+                  },
+                  {
+                    "type": "TLI",
+                    "name": "Science (General)"
+                  }
+                ],
+                "titleCustom": false,
+                "pubType": "Journal",
+                "contributorsList": [],
+                "customerResourcesList": [
+                  {
+                    "titleId": 640633,
+                    "packageId": 863,
+                    "packageName": "PubMed Central (PMC) Open Access",
+                    "packageType": "Variable",
+                    "isPackageCustom": false,
+                    "vendorId": 83,
+                    "vendorName": "PubMed Central/National Library of Medicine",
+                    "locationId": 13482249,
+                    "isSelected": true,
+                    "isTokenNeeded": false,
+                    "managedCoverageList": [
+                      {
+                        "beginCoverage": "2012-01-01",
+                        "endCoverage": "9999-12-31"
+                      }
+                    ],
+                    "customCoverageList": [],
+                    "managedEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "customEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "url": "https://www.ncbi.nlm.nih.gov/pmc/?term=%22Nat+Commun%22%5Bjournal%5D",
+                    "linkOutTargetUrl": "https://ebscois-staging.apigee.net/public/rma-pfapi/v1/pf/external-link/674d2081-1b68-4442-9e9b-ff6c3176dc61/5f9e2285-c57b-4716-8cfa-017bdbef16fd",
+                    "vendorToken": {
+                      "value": ""
+                    },
+                    "packageToken": {},
+                    "note": [
+                      {
+                        "id": 43138,
+                        "custId": 1123,
+                        "noteName": "domain",
+                        "rank": 1,
+                        "noteText": "domain note 03.20.20\n",
+                        "showOnFlags": [
+                          "PubDetails"
+                        ],
+                        "iconUrl": "",
+                        "altText": "",
+                        "hoverText": "",
+                        "linkUrl": ""
+                      }
+                    ],
+                    "userDefinedFields": [],
+                    "visibilityData": {
+                      "isHidden": true,
+                      "reason": ""
+                    },
+                    "customerId": 1123
+                  },
+                  {
+                    "titleId": 640633,
+                    "packageId": 2432142,
+                    "packageName": "Nature (MINCYT)",
+                    "packageType": "Complete",
+                    "isPackageCustom": false,
+                    "vendorId": 36,
+                    "vendorName": "Springer Nature",
+                    "locationId": 17016224,
+                    "isSelected": true,
+                    "isTokenNeeded": false,
+                    "managedCoverageList": [
+                      {
+                        "beginCoverage": "2010-04-01",
+                        "endCoverage": "9999-12-31"
+                      }
+                    ],
+                    "customCoverageList": [],
+                    "managedEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "customEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "url": "https://www.nature.com/ncomms/articles",
+                    "linkOutTargetUrl": "https://ebscois-staging.apigee.net/public/rma-pfapi/v1/pf/external-link/674d2081-1b68-4442-9e9b-ff6c3176dc61/55e1ae14-61f5-42d9-a280-dd0ffee1276d",
+                    "vendorToken": {
+                      "value": ""
+                    },
+                    "packageToken": {},
+                    "note": [
+                      {
+                        "id": 43138,
+                        "custId": 1123,
+                        "noteName": "domain",
+                        "rank": 1,
+                        "noteText": "domain note 03.20.20\n",
+                        "showOnFlags": [
+                          "PubDetails"
+                        ],
+                        "iconUrl": "",
+                        "altText": "",
+                        "hoverText": "",
+                        "linkUrl": ""
+                      }
+                    ],
+                    "userDefinedFields": [],
+                    "visibilityData": {
+                      "isHidden": true,
+                      "reason": ""
+                    },
+                    "customerId": 1123
+                  },
+                  {
+                    "titleId": 640633,
+                    "packageId": 1616,
+                    "packageName": "Nature Journals Online (Open Access)",
+                    "packageType": "Variable",
+                    "isPackageCustom": false,
+                    "vendorId": 36,
+                    "vendorName": "Springer Nature",
+                    "locationId": 4165844,
+                    "isSelected": true,
+                    "isTokenNeeded": false,
+                    "managedCoverageList": [
+                      {
+                        "beginCoverage": "2010-12-01",
+                        "endCoverage": "9999-12-31"
+                      }
+                    ],
+                    "customCoverageList": [
+                      {
+                        "beginCoverage": "2010-04-01",
+                        "endCoverage": "9999-12-31"
+                      }
+                    ],
+                    "managedEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "customEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "url": "https://www.nature.com/ncomms/volumes",
+                    "linkOutTargetUrl": "https://ebscois-staging.apigee.net/public/rma-pfapi/v1/pf/external-link/674d2081-1b68-4442-9e9b-ff6c3176dc61/9125d898-1430-43ff-8767-dce19cf2f562",
+                    "vendorToken": {
+                      "value": ""
+                    },
+                    "packageToken": {},
+                    "note": [
+                      {
+                        "id": 43138,
+                        "custId": 1123,
+                        "noteName": "domain",
+                        "rank": 1,
+                        "noteText": "domain note 03.20.20\n",
+                        "showOnFlags": [
+                          "PubDetails"
+                        ],
+                        "iconUrl": "",
+                        "altText": "",
+                        "hoverText": "",
+                        "linkUrl": ""
+                      }
+                    ],
+                    "userDefinedFields": [],
+                    "visibilityData": {
+                      "isHidden": true,
+                      "reason": ""
+                    },
+                    "customerId": 1123
+                  },
+                  {
+                    "titleId": 640633,
+                    "packageId": 5604,
+                    "packageName": "MEDLINE Complete",
+                    "packageType": "Complete",
+                    "isPackageCustom": false,
+                    "vendorId": 19,
+                    "vendorName": "EBSCO",
+                    "locationId": 9198764,
+                    "isSelected": true,
+                    "isTokenNeeded": false,
+                    "managedCoverageList": [
+                      {
+                        "beginCoverage": "2012-11-01",
+                        "endCoverage": "9999-12-31"
+                      }
+                    ],
+                    "customCoverageList": [],
+                    "managedEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "customEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "url": "https://search.ebscohost.com/direct.asp?db=mdc&jid=101528555&scope=site",
+                    "linkOutTargetUrl": "https://ebscois-staging.apigee.net/public/rma-pfapi/v1/pf/external-link/674d2081-1b68-4442-9e9b-ff6c3176dc61/f93f34e7-24e5-4a3b-a25e-4e2290120a52",
+                    "vendorToken": {
+                      "value": ""
+                    },
+                    "packageToken": {},
+                    "note": [
+                      {
+                        "id": 43138,
+                        "custId": 1123,
+                        "noteName": "domain",
+                        "rank": 1,
+                        "noteText": "domain note 03.20.20\n",
+                        "showOnFlags": [
+                          "PubDetails"
+                        ],
+                        "iconUrl": "",
+                        "altText": "",
+                        "hoverText": "",
+                        "linkUrl": ""
+                      },
+                      {
+                        "id": 34599,
+                        "custId": 1123,
+                        "noteName": "Derek Note 2- set to show for PF UI",
+                        "rank": 1,
+                        "noteText": "<strong>Derek Note 2</strong>- set to show for PF UI\n",
+                        "showOnFlags": [
+                          "LinkSource",
+                          "PubDetails"
+                        ],
+                        "iconUrl": "",
+                        "altText": "",
+                        "hoverText": "hover text",
+                        "linkUrl": ""
+                      }
+                    ],
+                    "userDefinedFields": [],
+                    "visibilityData": {
+                      "isHidden": true,
+                      "reason": ""
+                    },
+                    "customerId": 1123
+                  },
+                  {
+                    "titleId": 640633,
+                    "packageId": 1157839,
+                    "packageName": "Nature Journals Online (NESLi2)",
+                    "packageType": "Complete",
+                    "isPackageCustom": false,
+                    "vendorId": 36,
+                    "vendorName": "Springer Nature",
+                    "locationId": 9710251,
+                    "isSelected": true,
+                    "isTokenNeeded": false,
+                    "managedCoverageList": [
+                      {
+                        "beginCoverage": "2010-01-01",
+                        "endCoverage": "9999-12-31"
+                      }
+                    ],
+                    "customCoverageList": [],
+                    "managedEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "customEmbargoPeriod": {
+                      "embargoValue": 0
+                    },
+                    "url": "https://www.nature.com/ncomms/articles",
+                    "linkOutTargetUrl": "https://ebscois-staging.apigee.net/public/rma-pfapi/v1/pf/external-link/674d2081-1b68-4442-9e9b-ff6c3176dc61/794fdad8-94db-49d3-a0d9-bbef032b8160",
+                    "vendorToken": {
+                      "value": ""
+                    },
+                    "packageToken": {},
+                    "note": [
+                      {
+                        "id": 43138,
+                        "custId": 1123,
+                        "noteName": "domain",
+                        "rank": 1,
+                        "noteText": "domain note 03.20.20\n",
+                        "showOnFlags": [
+                          "PubDetails"
+                        ],
+                        "iconUrl": "",
+                        "altText": "",
+                        "hoverText": "",
+                        "linkUrl": ""
+                      }
+                    ],
+                    "userDefinedFields": [],
+                    "visibilityData": {
+                      "isHidden": true,
+                      "reason": ""
+                    },
+                    "customerId": 1123
+                  }
+                ],
+                "duration": "0",
+                "frequency": "1",
+                "alternateTitleList": [],
+                "licenseTerms": {
+                  "enabled": true,
+                  "noteLabel": "Public Note:"
                 }
               }
             }
@@ -1328,6 +1688,120 @@
                   }
                 ]
               }
+            },
+            "examples": {
+              "License terms data": [
+                {
+                  "label": "Definition of authorised user",
+                  "primary": true,
+                  "publicNote": "Walk-Ins must register for temporary UN/PW at circ desk on level 1",
+                  "value": [
+                    "Faculty, Student, Staff and Walk-Ins"
+                  ],
+                  "weight": -1
+                },
+                {
+                  "label": "Access restricted to on-campus/campus network?",
+                  "primary": true,
+                  "value": [
+                    "No"
+                  ],
+                  "weight": 0
+                },
+                {
+                  "label": "Making digital copies",
+                  "primary": true,
+                  "value": [
+                    "Permitted (explicit)"
+                  ],
+                  "weight": 0
+                },
+                {
+                  "label": "Number of concurrent users allowed",
+                  "primary": true,
+                  "publicNote": "If 40 users are already in the database, a concurrent user error will appear",
+                  "value": [
+                    "40"
+                  ],
+                  "weight": 0
+                },
+                {
+                  "label": "Secure Electronic ILL",
+                  "primary": true,
+                  "value": [
+                    "Prohibited (interpreted)"
+                  ],
+                  "weight": 0
+                },
+                {
+                  "label": "Use in electronic coursepacks",
+                  "primary": true,
+                  "value": [
+                    "Permitted (explicit)"
+                  ],
+                  "weight": 0
+                },
+                {
+                  "label": "Use in print course packs",
+                  "primary": true,
+                  "value": [
+                    "Permitted (explicit)"
+                  ],
+                  "weight": 0
+                },
+                {
+                  "label": "Walk-in access permitted?",
+                  "primary": true,
+                  "value": [
+                    "Yes"
+                  ],
+                  "weight": 0
+                },
+                {
+                  "label": "Example Decimal",
+                  "primary": true,
+                  "publicNote": "test testing",
+                  "value": [
+                    "2.7"
+                  ],
+                  "weight": 2
+                },
+                {
+                  "label": "test multi select",
+                  "primary": true,
+                  "value": [
+                    "Implicit",
+                    "negotiated"
+                  ],
+                  "weight": 2
+                },
+                {
+                  "label": "Low weight Additional Non-Primary",
+                  "primary": false,
+                  "publicNote": "whoooo!",
+                  "value": [
+                    "Alliance"
+                  ],
+                  "weight": 0
+                },
+                {
+                  "label": "Additional Non-Primary",
+                  "primary": false,
+                  "publicNote": "wheeeee!",
+                  "value": [
+                    "Alliance"
+                  ],
+                  "weight": 3
+                },
+                {
+                  "label": "Trial expires",
+                  "primary": false,
+                  "value": [
+                    "2023-09-30"
+                  ],
+                  "weight": 5
+                }
+              ]
             }
           },
           "400": {

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -11,7 +11,6 @@
     }
   },
   "host": "sandbox.ebsco.io",
-  "basePath": "/pf/pfaccount",
   "schemes": [
     "https"
   ],
@@ -27,7 +26,7 @@
     }
   ],
   "paths": {
-    "/{profile}/allpackages": {
+    "/pf/pfaccount/{profile}/allpackages": {
       "get": {
         "tags": [
           "Package Resources"
@@ -104,9 +103,17 @@
             "description": "Service Unavailable"
           }
         }
-      }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "name": "profile",
+          "in": "path",
+          "required": true
+        }
+      ]
     },
-    "/{profile}/alphabrowser/menu/{localeid}": {
+    "/pf/pfaccount/{profile}/alphabrowser/menu/{localeid}": {
       "get": {
         "tags": [
           "Alpha Browser Resource"
@@ -191,9 +198,23 @@
             "description": "Service Unavailable"
           }
         }
-      }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "name": "profile",
+          "in": "path",
+          "required": true
+        },
+        {
+          "type": "string",
+          "name": "localeid",
+          "in": "path",
+          "required": true
+        }
+      ]
     },
-    "/{profile}/packages": {
+    "/pf/pfaccount/{profile}/packages": {
       "get": {
         "tags": [
           "Package Resources"
@@ -306,9 +327,17 @@
             "description": "Service Unavailable"
           }
         }
-      }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "name": "profile",
+          "in": "path",
+          "required": true
+        }
+      ]
     },
-    "/{profile}/packages/{packageid}/titles/{kbid}": {
+    "/pf/pfaccount/{profile}/packages/{packageid}/titles/{kbid}": {
       "get": {
         "tags": [
           "Title Resources"
@@ -382,28 +411,35 @@
             "description": "Service Unavailable"
           }
         }
-      }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "name": "profile",
+          "in": "path",
+          "required": true
+        },
+        {
+          "type": "string",
+          "name": "packageid",
+          "in": "path",
+          "required": true
+        },
+        {
+          "type": "string",
+          "name": "kbid",
+          "in": "path",
+          "required": true
+        }
+      ]
     },
-    "/{profile}/publications": {
+    "/pf/pfaccount/{profile}/publications": {
       "get": {
         "tags": [
           "Title Resources"
         ],
         "summary": "Get Publications by Specified Title Attributes",
-        "description": "This resource allows you to search for publications and returns a list of publications.  The list is limited to a single customer ID.  The response will reflect the context of the EBSCO customer ID included in the request.  Access to PublicationIQ requires a Publication Finder customer profile.  A profile password is optional.  If a password is supplied, it must be a valid password assigned to the Publication Finder customer profile.  If the password is omitted, the request will only be honored if the Publication Finder customer profile allows guest access in the environment where you are making the request.  For example, if you would like to make a request to PublicationIQ in the sandbox environment without a password, guest access must be enabled for the Publication Finder customer profile in the sandbox environment.  The same is true in the production environment.  This documentation uses the sandbox environment.  In order to gain access to the PublicationIQ sandbox environment, please contact EBSCO customer support.<p>&nbsp;&nbsp;</p><p>**Please Note:**  When creating logic to interpret the response coverage details, we recommend that you use the following pseudocode example as a guide:
-		<p>&nbsp;&nbsp;</p><p>
-		  &nbsp;&nbsp;If Coverage Statement is NOT Null THEN (Note: empty string, \"\", should be treated as a valid coverage statement)<br>
-		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Show Coverage Statement <br>
-		  &nbsp;&nbsp;ELSE IF Custom Coverage Dates exist THEN<br>
-		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;IF Custom Coverage Date = \"01/01/0001\" THEN <br>
-		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Do not display any coverage<br>
-		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ELSE <br>
-		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Show Custom Coverage<br>
-		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;END IF <br>
-		  &nbsp;&nbsp;ELSE <br>
-		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Show Managed Coverage<br>
-		  &nbsp;&nbsp;END IF
-		",
+        "description": "This resource allows you to search for publications and returns a list of publications.  The list is limited to a single customer ID.  The response will reflect the context of the EBSCO customer ID included in the request.  Access to PublicationIQ requires a Publication Finder customer profile.  A profile password is optional.  If a password is supplied, it must be a valid password assigned to the Publication Finder customer profile.  If the password is omitted, the request will only be honored if the Publication Finder customer profile allows guest access in the environment where you are making the request.  For example, if you would like to make a request to PublicationIQ in the sandbox environment without a password, guest access must be enabled for the Publication Finder customer profile in the sandbox environment.  The same is true in the production environment.  This documentation uses the sandbox environment.  In order to gain access to the PublicationIQ sandbox environment, please contact EBSCO customer support.",
         "operationId": "findPublicationsUsingGET",
         "consumes": [
           "application/json"
@@ -650,6 +686,710 @@
             "description": "Service Unavailable"
           }
         }
+      },
+      "parameters": [
+        {
+          "type": "string",
+          "name": "profile",
+          "in": "path",
+          "required": true
+        }
+      ]
+    },
+    "/pf/v1/pfaccount/{profile}/title/{kbid}": {
+      "parameters": [
+        {
+          "type": "string",
+          "name": "profile",
+          "in": "path",
+          "required": true,
+          "description": "EBSCO customer profile. e.g. 'demo.main.pfiguest'"
+        },
+        {
+          "type": "string",
+          "name": "kbid",
+          "in": "path",
+          "required": true,
+          "description": "Title ID. e.g. '1385382'"
+        }
+      ],
+      "get": {
+        "summary": "Retrieves singular title details for a customer",
+        "tags": [
+          "Title Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK, Title details for a given KBID",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "titleId": {
+                  "type": "string"
+                },
+                "titleName": {
+                  "type": "string"
+                },
+                "edition": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "peerReviewed": {
+                  "type": "boolean"
+                },
+                "publisherName": {
+                  "type": "string"
+                },
+                "identifiersList": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "integer"
+                      },
+                      "subtype": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                },
+                "subjectsList": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "titleCustom": {
+                  "type": "boolean"
+                },
+                "pubType": {
+                  "type": "string"
+                },
+                "contributorsList": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      },
+                      "contributor": {
+                        "type": "string"
+                      },
+                      "displayOrder": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                },
+                "customerResourcesList": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "titleId": {
+                        "type": "integer"
+                      },
+                      "packageId": {
+                        "type": "integer"
+                      },
+                      "packageName": {
+                        "type": "string"
+                      },
+                      "packageType": {
+                        "type": "string"
+                      },
+                      "isPackageCustom": {
+                        "type": "boolean"
+                      },
+                      "vendorId": {
+                        "type": "integer"
+                      },
+                      "vendorName": {
+                        "type": "string"
+                      },
+                      "locationId": {
+                        "type": "integer"
+                      },
+                      "isSelected": {
+                        "type": "boolean"
+                      },
+                      "isTokenNeeded": {
+                        "type": "boolean"
+                      },
+                      "managedCoverageList": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "beginCoverage": {
+                              "type": "string"
+                            },
+                            "endCoverage": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "customCoverageList": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "beginCoverage": {
+                              "type": "string"
+                            },
+                            "endCoverage": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "coverageStatement": {
+                        "type": "string"
+                      },
+                      "managedEmbargoPeriod": {
+                        "type": "object",
+                        "properties": {
+                          "embargoUnit": {
+                            "type": "string"
+                          },
+                          "embargoValue": {
+                            "type": "integer"
+                          }
+                        }
+                      },
+                      "customEmbargoPeriod": {
+                        "type": "object",
+                        "properties": {
+                          "embargoUnit": {
+                            "type": "string"
+                          },
+                          "embargoValue": {
+                            "type": "integer"
+                          }
+                        }
+                      },
+                      "url": {
+                        "type": "string"
+                      },
+                      "linkOutTargetUrl": {
+                        "type": "string"
+                      },
+                      "vendorToken": {
+                        "type": "object",
+                        "properties": {
+                          "factName": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "packageToken": {
+                        "type": "object",
+                        "properties": {
+                          "factName": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "targetUrl": {
+                        "type": "string"
+                      },
+                      "proxy": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "inherited": {
+                            "type": "boolean"
+                          },
+                          "proxyName": {
+                            "type": "string"
+                          },
+                          "urlMask": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "note": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer"
+                            },
+                            "custId": {
+                              "type": "integer"
+                            },
+                            "noteName": {
+                              "type": "string"
+                            },
+                            "rank": {
+                              "type": "integer"
+                            },
+                            "noteText": {
+                              "type": "string"
+                            },
+                            "showOnFlags": {
+                              "type": "object",
+                              "properties": {}
+                            },
+                            "iconUrl": {
+                              "type": "string"
+                            },
+                            "iconId": {
+                              "type": "integer"
+                            },
+                            "altText": {
+                              "type": "string"
+                            },
+                            "hoverText": {
+                              "type": "string"
+                            },
+                            "linkUrl": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "userDefinedFields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer"
+                            },
+                            "label": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "displayOnPublicationFinder": {
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      },
+                      "visibilityData": {
+                        "type": "object",
+                        "properties": {
+                          "isHidden": {
+                            "type": "boolean"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "customerId": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                },
+                "duration": {
+                  "type": "string"
+                },
+                "frequency": {
+                  "type": "string"
+                },
+                "alternateTitleList": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "alternateTitle": {
+                        "type": "string"
+                      },
+                      "titleType": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "imageLink": {
+                  "type": "string"
+                },
+                "licenseTerms": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "noteLabel": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "x-examples": {
+                "Example 1": {
+                  "titleId": "string",
+                  "titleName": "string",
+                  "edition": "string",
+                  "description": "string",
+                  "peerReviewed": true,
+                  "publisherName": "string",
+                  "identifiersList": [
+                    {
+                      "id": "string",
+                      "source": "string",
+                      "type": 0,
+                      "subtype": 0
+                    }
+                  ],
+                  "subjectsList": [
+                    {
+                      "type": "string",
+                      "name": "string"
+                    }
+                  ],
+                  "titleCustom": true,
+                  "pubType": "string",
+                  "contributorsList": [
+                    {
+                      "type": "string",
+                      "contributor": "string",
+                      "displayOrder": 0
+                    }
+                  ],
+                  "customerResourcesList": [
+                    {
+                      "titleId": 0,
+                      "packageId": 0,
+                      "packageName": "string",
+                      "packageType": "string",
+                      "isPackageCustom": true,
+                      "vendorId": 0,
+                      "vendorName": "string",
+                      "locationId": 0,
+                      "isSelected": true,
+                      "isTokenNeeded": true,
+                      "managedCoverageList": [
+                        {
+                          "beginCoverage": "2003-01-01",
+                          "endCoverage": "2003-12-12"
+                        }
+                      ],
+                      "customCoverageList": [
+                        {
+                          "beginCoverage": "2003-01-01",
+                          "endCoverage": "2003-12-12"
+                        }
+                      ],
+                      "coverageStatement": "string",
+                      "managedEmbargoPeriod": {
+                        "embargoUnit": "string",
+                        "embargoValue": 0
+                      },
+                      "customEmbargoPeriod": {
+                        "embargoUnit": "string",
+                        "embargoValue": 0
+                      },
+                      "url": "string",
+                      "linkOutTargetUrl": "string",
+                      "vendorToken": {
+                        "factName": "string",
+                        "value": "string"
+                      },
+                      "packageToken": {
+                        "factName": "string",
+                        "value": "string"
+                      },
+                      "targetUrl": "string",
+                      "proxy": {
+                        "id": "string",
+                        "inherited": true,
+                        "proxyName": "string",
+                        "urlMask": "string"
+                      },
+                      "note": [
+                        {
+                          "id": 0,
+                          "custId": 0,
+                          "noteName": "string",
+                          "rank": 0,
+                          "noteText": "string",
+                          "showOnFlags": {},
+                          "iconUrl": "string",
+                          "iconId": 0,
+                          "altText": "string",
+                          "hoverText": "string",
+                          "linkUrl": "string"
+                        }
+                      ],
+                      "userDefinedFields": [
+                        {
+                          "id": 0,
+                          "label": "string",
+                          "value": "string",
+                          "displayOnPublicationFinder": true
+                        }
+                      ],
+                      "visibilityData": {
+                        "isHidden": true,
+                        "reason": "Hidden by Customer"
+                      },
+                      "customerId": 0
+                    }
+                  ],
+                  "duration": "string",
+                  "frequency": "string",
+                  "alternateTitleList": [
+                    {
+                      "alternateTitle": "string",
+                      "titleType": "string"
+                    }
+                  ],
+                  "imageLink": "string",
+                  "licenseTerms": {
+                    "enabled": false,
+                    "noteLabel": "string"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "502": {
+            "description": "Bad Gateway",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "operationId": "get-pf-v1-pfaccount-profile-title-kbid",
+        "description": "This operation allows you to search with an individual title and returns a details associated with that individual title. The title is limited to a single customer ID. The response will reflect the context of the EBSCO customer ID included in the request.",
+        "parameters": [
+          {
+            "type": "string",
+            "in": "query",
+            "name": "sessionid",
+            "description": "Already existing SessionId can be provided to improve experience of using the publications search. Example format -> '-2689046726050171609'"
+          },
+          {
+            "type": "boolean",
+            "in": "query",
+            "name": "returnrelativeimagelinks",
+            "description": "Return relative links or direct links to cover images"
+          },
+          {
+            "type": "string",
+            "in": "header",
+            "name": "password",
+            "description": "Profile Password (optional).  If a password is supplied, it must be a valid password assigned to the customer profile.  If omitted, the request will only be honored if the customer profile allows guest access."
+          }
+        ]
+      }
+    },
+    "/pf/v1/pfaccount/{profile}/vendor/{vendorid}/package/{packageid}/title/{kbid}/licenseterms": {
+      "parameters": [
+        {
+          "type": "string",
+          "name": "profile",
+          "in": "path",
+          "required": true,
+          "description": "EBSCO customer profile. e.g. 'demo.main.pfiguest'"
+        },
+        {
+          "type": "string",
+          "name": "vendorid",
+          "in": "path",
+          "required": true,
+          "description": "Vendor ID. e.g. '134386'"
+        },
+        {
+          "type": "string",
+          "name": "packageid",
+          "in": "path",
+          "required": true,
+          "description": "Package ID. e.g. '4077736'"
+        },
+        {
+          "type": "string",
+          "name": "kbid",
+          "in": "path",
+          "required": true,
+          "description": "Title ID. e.g. '1385382'"
+        }
+      ],
+      "get": {
+        "summary": "Returns ILS data by VendorId, PackageId (List Id) and TitleId",
+        "tags": [
+          "Title Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK, License terms data",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "weight": {
+                    "type": "integer"
+                  },
+                  "publicNote": {
+                    "type": "string"
+                  },
+                  "primary": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "x-examples": {
+                "Example 1": [
+                  {
+                    "label": "string",
+                    "value": [
+                      "string"
+                    ],
+                    "weight": 0,
+                    "publicNote": "string",
+                    "primary": true
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "502": {
+            "description": "Bad Gateway",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "operationId": "get-pf-v1-pfaccount-profile-vendor-vendorid-package-packageid-title-kbid-licenseterms",
+        "description": "Retrieves license term data of from ILS API",
+        "parameters": [
+          {
+            "type": "string",
+            "in": "header",
+            "name": "password",
+            "description": "Profile Password (optional).  If a password is supplied, it must be a valid password assigned to the customer profile.  If omitted, the request will only be honored if the customer profile allows guest access."
+          }
+        ]
       }
     }
   },
@@ -784,7 +1524,7 @@
         "embargoValue": {
           "type": "integer",
           "description": "The embargo value (number of embargoUnits).  A Null value means there is no embargo.",
-          "example": "1"
+          "example": 1
         }
       }
     },
@@ -860,7 +1600,7 @@
           "type": "integer",
           "format": "int64",
           "description": "Customer ID",
-          "example": "1123"
+          "example": 1123
         }
       }
     },
@@ -1373,7 +2113,7 @@
           "type": "integer",
           "format": "int64",
           "description": "Unique identifier for the note",
-          "example": "309"
+          "example": 309
         },
         "custId": {
           "type": "integer",
@@ -1461,6 +2201,14 @@
         }
       }
     },
+    "QueriesWithAction": {
+      "type": "object",
+      "properties": {
+        "Query": {
+          "$ref": "#/definitions/Query"
+        }
+      }
+    },
     "PackageFacet": {
       "type": "object",
       "properties": {
@@ -1482,21 +2230,13 @@
         }
       }
     },
-    "QueriesWithAction": {
-      "type": "object",
-      "properties": {
-        "Query": {
-          "$ref": "#/definitions/Query"
-        }
-      }
-    },
     "IdentifiersList": {
       "type": "object",
       "properties": {
         "id": {
           "type": "string",
           "description": "Identifier Value",
-          "example": 1
+          "example": "1"
         },
         "source": {
           "type": "string",
@@ -1537,7 +2277,7 @@
           "type": "integer",
           "format": "int64",
           "description": "ID",
-          "example": "a123"
+          "example": 123
         },
         "label": {
           "type": "string",

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -10,7 +10,7 @@
       "url": "https://www.ebsco.com/terms-of-use"
     }
   },
-  "host": "sandbox.ebsco.io",
+  "host": "sandbox.ebsco.ioo",
   "basePath": "/pf/pfaccount",
   "schemes": [
     "https"

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -10,7 +10,7 @@
       "url": "https://www.ebsco.com/terms-of-use"
     }
   },
-  "host": "sandbox.ebsco.ioo",
+  "host": "sandbox.ebsco.io",
   "basePath": "/pf/pfaccount",
   "schemes": [
     "https"
@@ -390,11 +390,11 @@
           "Title Resources"
         ],
         "summary": "Get Publications by Specified Title Attributes",
-        "description": "This resource allows you to search for publications and returns a list of publications.  The list is limited to a single customer ID.  The response will reflect the context of the EBSCO customer ID included in the request.  Access to PublicationIQ requires a Publication Finder customer profile.  A profile password is optional.  If a password is supplied, it must be a valid password assigned to the Publication Finder customer profile.  If the password is omitted, the request will only be honored if the Publication Finder customer profile allows guest access in the environment where you are making the request.  For example, if you would like to make a request to PublicationIQ in the sandbox environment without a password, guest access must be enabled for the Publication Finder customer profile in the sandbox environment.  The same is true in the production environment.  This documentation uses the sandbox environment.  In order to gain access to the PublicationIQ sandbox environment, please contact EBSCO customer support.<p>&nbsp;&nbsp;</p><p>**Please Note:**  When creating logic to interpret the response coverage details, we recommend that you use the following pseudocode example as a guide:  
+        "description": "This resource allows you to search for publications and returns a list of publications.  The list is limited to a single customer ID.  The response will reflect the context of the EBSCO customer ID included in the request.  Access to PublicationIQ requires a Publication Finder customer profile.  A profile password is optional.  If a password is supplied, it must be a valid password assigned to the Publication Finder customer profile.  If the password is omitted, the request will only be honored if the Publication Finder customer profile allows guest access in the environment where you are making the request.  For example, if you would like to make a request to PublicationIQ in the sandbox environment without a password, guest access must be enabled for the Publication Finder customer profile in the sandbox environment.  The same is true in the production environment.  This documentation uses the sandbox environment.  In order to gain access to the PublicationIQ sandbox environment, please contact EBSCO customer support.<p>&nbsp;&nbsp;</p><p>**Please Note:**  When creating logic to interpret the response coverage details, we recommend that you use the following pseudocode example as a guide:
 		<p>&nbsp;&nbsp;</p><p>
-		  &nbsp;&nbsp;If Coverage Statement is NOT Null THEN (Note: empty string, \"\", should be treated as a valid coverage statement)<br> 
+		  &nbsp;&nbsp;If Coverage Statement is NOT Null THEN (Note: empty string, \"\", should be treated as a valid coverage statement)<br>
 		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Show Coverage Statement <br>
-		  &nbsp;&nbsp;ELSE IF Custom Coverage Dates exist THEN<br> 
+		  &nbsp;&nbsp;ELSE IF Custom Coverage Dates exist THEN<br>
 		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;IF Custom Coverage Date = \"01/01/0001\" THEN <br>
 		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Do not display any coverage<br>
 		  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ELSE <br>


### PR DESCRIPTION
https://rally1.rallydev.com/#/109021077464d/iterationstatus?detail=%2Fuserstory%2F706180555985

- added two new endpoints for PFAPI
- removed base path and added path prefix to individual paths since we now have v1 endpoints included
- fixed a few miscellaneous openapi errors

If you want to compare to the api spec for rma-pfapi service itself, the two endpoints can be found here:
- https://ebsco.stoplight.io/docs/rma-pfapi/branches/main/da6fa0cefcea9-returns-ils-data-by-vendor-id-package-id-list-id-and-title-id
- https://ebsco.stoplight.io/docs/rma-pfapi/branches/main/c6cb1bf9e10b3-retrieves-singular-title-details-for-a-customer

@pdestefano feel free to use this as a baseline or as-is! Thanks

**Note** this should not be merged until[ this PR](https://github.com/EBSCOIS/platform.shared.gateway-internal/pull/215) is complete as until then, the new endpoints will not be functional on sandbox.ebsco.io