### PR TITLE
US1252872 - Add new V1 packages endpoint to PubIQ

### DIFF
--- a/publicationiq.json
+++ b/publicationiq.json
@@ -6195,28 +6195,11 @@
         "vendorName": {
           "type": "string"
         },
-        "visibility": {
-          "$ref": "#/definitions/Visibility"
-        },
         "visibilityData": {
           "$ref": "#/definitions/VisibilityData"
         }
       }
     },
-    "Visibility": {
-      "type": "array",
-      "properties": {
-        "category": {
-          "type": "string"
-        },
-        "hidden": {
-          "type": "boolean"
-        },
-        "reason": {
-          "type": "string"
-        }
-      }
-    }
   },
   "parameters": {
     "Password": {

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -5805,6 +5805,10 @@
         "totalResults": {
           "type": "integer",
           "format": "int64"
+        },
+        "totalSearchTime": {
+          "type": "integer",
+          "format": "int64"
         }
       }
     },
@@ -6097,10 +6101,6 @@
         },
         "customDisplayName": {
           "type": "string"
-        },
-        "customerId": {
-          "type": "integer",
-          "format": "int64"
         },
         "isCustom": {
           "type": "boolean"

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -5001,6 +5001,145 @@
           }
         ]
       }
+    },
+    "/pf/v1/pfaccount/{profile}/packages": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/Profile"
+        },
+        {
+          "$ref": "#/parameters/Password"
+        },
+        {
+          "name": "sessionid",
+          "in": "query",
+          "description": "If provided, improves the experience of using the publications search. Sessionid is an optional parameter.",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "search",
+          "type": "string",
+          "description": "Keyword search that is applied to limit the results to packages that have the search term in the package name.",
+          "in": "query",
+          "required": true
+        },
+        {
+          "name": "orderby",
+          "in": "query",
+          "description": "Valid values are packagename and relevance.",
+          "required": true,
+          "type": "string",
+          "enum": [
+            "relevance",
+            "titlename"
+          ]
+        },
+        {
+          "name": "offset",
+          "in": "query",
+          "description": "Page Offset. Starts at 1.",
+          "required": true,
+          "type": "string",
+          "default": "1"
+        },
+        {
+          "name": "count",
+          "in": "query",
+          "description": "The maximum number of results to return in the response. Maximum count value is 100.",
+          "required": true,
+          "type": "string",
+          "default": "10"
+        },
+        {
+          "name": "contenttype",
+          "in": "query",
+          "description": "Limits the results by type of package content. Valid values are all, aggregatedfulltext, abstractandindex, ebook, ejournal, print, unknown and onlinereference. It is also valid to use 0 for all, 1 for aggregated full text, 2 for abstract and index, 3 for ebook, 4 for ejournal, 5 for print, 6 for unknown or 7 for online reference.",
+          "required": false,
+          "type": "string",
+          "enum": [
+            "all",
+            "aggregatedfulltext",
+            "abstractandindex",
+            "ebook",
+            "ejournal",
+            "print",
+            "unknown",
+            "onlinereference",
+            "streamingmedia",
+            "mixedcontent"
+          ]
+        },
+        {
+          "name": "searchtype",
+          "in": "query",
+          "description": "Type of search. Search types are any, contains, exactmatch, beginswith, exactphrase and advanced. Searchtype is an optional parameter and defaults to contains if not provided.",
+          "required": false,
+          "type": "string",
+          "enum": [
+            "any",
+            "contains",
+            "advanced",
+            "exactmatch",
+            "beginswith",
+            "exactphrase"
+          ]
+        },
+        {
+          "name": "searchField",
+          "in": "query",
+          "description": "Field to search. e.g. 'KEYWORKD'.",
+          "required": false,
+          "type": "string",
+          "enum": [
+            "name",
+            "keyword"
+          ]
+        },
+        {
+          "name": "highlighttag",
+          "in": "query",
+          "required": false,
+          "type": "string"
+        }
+      ],
+      "get": {
+        "tags": [
+          "Package Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GetPackagesResultV2"
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "description": "Bad Gateway"
+          },
+          "503": {
+            "description": "Service Unavailable"
+          }
+        },
+        "operationId": "get-v1-pfaccount-packages",
+        "description": "This resource allows you to search for packages and returns a list of packages from EPKB. The list is limited to a single customer ID. The response will reflect the context of the EBSCO customer ID included in the request.  Access to PublicationIQ requires a Publication Finder customer profile.  A profile password is optional.  If a password is supplied, it must be a valid password assigned to the Publication Finder customer profile.  If the password is omitted, the request will only be honored if the Publication Finder customer profile allows guest access in the environment where you are making the request.  For example, if you would like to make a request to PublicationIQ in the sandbox environment without a password, guest access must be enabled for the Publication Finder customer profile in the sandbox environment.  The same is true in the production environment.  This documentation uses the sandbox environment.  In order to gain access to the PublicationIQ sandbox environment, please contact EBSCO customer support.",
+        "summary": "Get Packages by Package Name"
+      }
     }
   },
   "definitions": {
@@ -5653,6 +5792,21 @@
         }
       }
     },
+    "GetPackagesResultV2": {
+      "type": "object",
+      "properties": {
+        "packagesList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PackageSearchDetails"
+          }
+        },
+        "totalResults": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
     "Data": {
       "type": "object",
       "properties": {
@@ -5919,6 +6073,147 @@
           "type": "string",
           "description": "Content type. Valid values are All, AggregatedFullText, AbstractandIndex, EBook, EJournal, Print, Unknown and OnlineReference.",
           "example": "EBook"
+        }
+      }
+    },
+    "PackageSearchDetails": {
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string"
+        },
+        "customCoverage": {
+          "$ref": "#/definitions/CustomCoverage"
+        },
+        "customAltNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "customDescription": {
+          "type": "string"
+        },
+        "customDisplayName": {
+          "type": "string"
+        },
+        "customerId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "isCustom": {
+          "type": "boolean"
+        },
+        "isSelected": {
+          "type": "boolean"
+        },
+        "isTokenNeeded": {
+          "type": "boolean"
+        },
+        "managedAltNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "managedDescription": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "custId": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "noteName": {
+                "type": "string"
+              },
+              "rank": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "noteText": {
+                "type": "string"
+              },
+              "showOnFlags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "iconUrl": {
+                "type": "string"
+              },
+              "iconId": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "altText": {
+                "type": "string"
+              },
+              "hoverText": {
+                "type": "string"
+              },
+              "linkUrl": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "packageId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "packageName": {
+          "type": "string"
+        },
+        "packageType": {
+          "type": "string"
+        },
+        "proxiedUrl": {
+          "type": "string"
+        },
+        "selectedCount": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "titleCount": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "vendorId": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "vendorName": {
+          "type": "string"
+        },
+        "visibility": {
+          "$ref": "#/definitions/Visibility"
+        },
+        "visibilityData": {
+          "$ref": "#/definitions/VisibilityData"
+        }
+      }
+    },
+    "Visibility": {
+      "type": "array",
+      "properties": {
+        "category": {
+          "type": "string"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
         }
       }
     }

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -5047,7 +5047,6 @@
           "enum": [
             "relevance",
             "packagename"
-
           ]
         },
         {
@@ -5101,7 +5100,7 @@
           ]
         },
         {
-          "name": "searchField",
+          "name": "searchfield",
           "in": "query",
           "description": "Field to search. e.g. 'KEYWORKD'.",
           "required": false,
@@ -5114,6 +5113,48 @@
         {
           "name": "highlighttag",
           "in": "query",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "subjectfacetcount",
+          "in": "query",
+          "description": "Max count for subject facets to be returned. e.g. '10'",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "subjectfacetschemafilter",
+          "in":"query",
+          "description":"Specify the schema to filter the schema of the subjects facet.",
+          "required":false,
+          "type":"string",
+          "enum": [
+            "LIBRARY_OF_CONGRESS"
+          ]
+        },
+        {
+          "name": "includefacets",
+          "in": "query",
+          "description": "Specify **true** if search is required to include facet information, **false** otherwise.",
+          "required": false,
+          "type": "boolean"
+        },
+        {
+          "name": "subjectfacet",
+          "in": "query",
+          "description": "Subject Type Facet filtration option. Required in order to access specific titles via refined results. e.g. 'Medical'",
+          "required": false,
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "collectionFormat": "multi"
+        },
+        {
+          "name": "alphamenufacet",
+          "in": "query",
+          "description": "Alpha Menu Facet filtration option. Required in order to access specific titles via refined results. Only 1 Alpha Menu Facet value supported in query. e.g. 'A'",
           "required": false,
           "type": "string"
         },
@@ -5274,6 +5315,17 @@
           "type": "string",
           "description": "Subject Name",
           "example": "Subject Name"
+        }
+      }
+    },
+    "PfSubjectV1" : {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "name" : {
+          "type": "string"
         }
       }
     },
@@ -5839,6 +5891,9 @@
         "totalSearchTime": {
           "type": "integer",
           "format": "int64"
+        },
+        "facets": {
+          "$ref": "#/definitions/HSMPackageFacets"
         }
       }
     },
@@ -6029,6 +6084,48 @@
         }
       }
     },
+    "HSMPackageFacet": {
+      "type": "object",
+      "properties": {
+        "parentId": {
+          "type": "string",
+          "description": "Parent ID",
+          "example": "1615"
+        },
+        "id": {
+          "type": "string",
+          "description": "Package ID",
+          "example": "1615"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Count",
+          "example": 15
+        },
+        "name": {
+          "type": "string",
+          "description": "Package Name",
+          "example": "Academic Search Complete"
+        },
+        "subjectName" :{
+          "type": "string",
+          "description": "Subject Name",
+          "example": "Medical"
+        }
+      }
+    },
+    "HSMPackageFacets":{
+      "type": "object",
+      "properties": {
+        "subjects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HSMPackageFacet"
+          }
+        }
+      }
+    },
     "IdentifiersList": {
       "type": "object",
       "properties": {
@@ -6115,13 +6212,16 @@
       "type": "object",
       "properties": {
         "contentType": {
-          "type": "string"
+          "type": "string",
+          "description": "Content type. Valid values are All, AggregatedFullText, AbstractandIndex, EBook, EJournal, Print, Unknown and OnlineReference.",
+          "example": "EBook"
         },
         "customCoverage": {
           "$ref": "#/definitions/CustomCoverage"
         },
         "customAltNames": {
           "type": "array",
+          "description": "isCustom is true if a customer is the vendor.  The customer vendor is used for custom packages.",
           "items": {
             "type": "string"
           }
@@ -6133,13 +6233,19 @@
           "type": "string"
         },
         "isCustom": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "isCustom is true if a customer is the vendor.  The customer vendor is used for custom packages.",
+          "example": true
         },
         "isSelected": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Indicates if the packages is selected in a customer's account.",
+          "example": true
         },
         "isTokenNeeded": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Field to indicate if a token is needed",
+          "example": true
         },
         "managedAltNames": {
           "type": "array",
@@ -6200,37 +6306,57 @@
         },
         "packageId": {
           "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "description": "Package Identifier",
+          "example": 175
         },
         "packageName": {
-          "type": "string"
+          "type": "string",
+          "description": "Package Name",
+          "example": "Health Source: Nursing/Academic Edition"
         },
         "packageType": {
-          "type": "string"
+          "type": "string",
+          "description": "Package Type.  Valid values are Selectable, Complete, Variable and Custom.",
+          "example": "Complete"
         },
         "proxiedUrl": {
           "type": "string"
         },
         "selectedCount": {
           "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "description": "Numeric value indicating the number of titles in packages selected in the customer account.",
+          "example": 328
         },
         "titleCount": {
           "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "description": "Numeric value indicating the title count of the package.",
+          "example": 328
         },
         "vendorId": {
           "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "description": "EBSCO KB's unique identifier for the provider.  In EPKB, this is 'VendorID'.",
+          "example": 19
         },
         "vendorName": {
-          "type": "string"
+          "type": "string",
+          "description": "Provider name.  In EPKB, this is the 'VendorName'.",
+          "example": "EBSCO"
         },
         "visibilityData": {
           "$ref": "#/definitions/VisibilityData"
         },
         "url": {
           "type": "string"
+        },
+        "subjectsList": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PfSubjectV1"
+          }
         },
         "packageFreeAccess": {
           "type": "boolean"

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -5116,6 +5116,17 @@
           "in": "query",
           "required": false,
           "type": "string"
+        },
+        {
+          "name": "packagefreeaccess",
+          "in": "query",
+          "required": false,
+          "type": "string",
+          "enum": [
+            "all",
+            "true",
+            "false"
+          ]
         }
       ],
       "get": {
@@ -6220,9 +6231,12 @@
         },
         "url": {
           "type": "string"
+        },
+        "packageFreeAccess": {
+          "type": "boolean"
         }
       }
-    },
+    }
   },
   "parameters": {
     "Password": {

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -6198,6 +6198,9 @@
         },
         "visibilityData": {
           "$ref": "#/definitions/VisibilityData"
+        },
+        "url": {
+          "type": "string"
         }
       }
     },

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -5642,6 +5642,11 @@
           "type": "string",
           "description": "Target URL",
           "example": "http://target.url.io"
+        },
+        "displayname": {
+          "type": "string",
+          "description": "Display Name",
+          "example": "Display Name"
         }
       }
     },

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -1178,6 +1178,11 @@
                         "format": "int64",
                         "description": "Customer ID",
                         "example": "1123"
+                      },
+                      "displayName": {
+                        "type": "string",
+                        "description": "Display Name",
+                        "example": "Boston Pilot"
                       }
                     }
                   }
@@ -1920,6 +1925,10 @@
                                     "customerId": {
                                       "type": "integer",
 									  "description": "Customer ID"
+                                    },
+                                    "displayName": {
+                                      "type": "string",
+                                        "description": "Display Name"
                                     }
                                   }
                                 }
@@ -2247,7 +2256,8 @@
                               "isHidden": true,
                               "reason": ""
                             },
-                            "customerId": 1123
+                            "customerId": 1123,
+                            "displayName": "Boston Pilot"
                           },
                           {
                             "titleId": 50974,
@@ -2333,7 +2343,8 @@
                               "isHidden": true,
                               "reason": ""
                             },
-                            "customerId": 1123
+                            "customerId": 1123,
+                            "displayName": "Boston Pilot"
                           },
                           {
                             "titleId": 50974,
@@ -2401,7 +2412,8 @@
                               "isHidden": true,
                               "reason": ""
                             },
-                            "customerId": 1123
+                            "customerId": 1123,
+                            "displayName": "Boston Pilot"
                           },
                           {
                             "titleId": 50974,
@@ -2469,7 +2481,8 @@
                               "isHidden": true,
                               "reason": ""
                             },
-                            "customerId": 1123
+                            "customerId": 1123,
+                            "displayName": "Boston Pilot"
                           },
                           {
                             "titleId": 50974,
@@ -2537,7 +2550,8 @@
                               "isHidden": true,
                               "reason": ""
                             },
-                            "customerId": 1123
+                            "customerId": 1123,
+                            "displayName": "Boston Pilot"
                           },
                           {
                             "titleId": 50974,

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -5041,7 +5041,7 @@
         {
           "name": "orderby",
           "in": "query",
-          "description": "Valid values are packagename and relevance.",
+          "description": "Valid values are packagename and relevance. Note that orderby will always be treated as 'packagename' when the search term is blank.",
           "required": true,
           "type": "string",
           "enum": [


### PR DESCRIPTION
Introduces the new versioned packages endpoint to PubIQ


[US1252872](https://rally1.rallydev.com/#/?detail=/userstory/766601793523&fdp=true): F78567 [I2] PublicationIQ: Add New Query Params, Response Body and Documentation to Packages Endpoint
[US1269512](https://rally1.rallydev.com/#/?detail=/userstory/790727558149&fdp=true): F78567 Adjusted Package URL Logic - PFAPI, PubIQ, gateway, PFUI
[US1252905](https://rally1.rallydev.com/#/?detail=/userstory/766602531895&fdp=true): F78198 [I5] PubIQ: Update documentation for custom package display name
[US1306200](https://rally1.rallydev.com/#/?detail=/userstory/807240664819&fdp=true): PubIQ and rma-rmapigateway: Changes for Freely Available
Commit [f280218](https://github.com/pdestefano/developer_portal_openapi/pull/12/commits/f2802182e1c97a02d60bb35cdea92b33dec3a1d7) is intended as a replacement for PR 21: https://github.com/pdestefano/developer_portal_openapi/pull/21
[US1310092](https://rally1.rallydev.com/#/?detail=/userstory/809768739851&fdp=true): CO: PFAPI - Update default orderby for blank searches