### PR TITLE
US1310092 - PubIQ v1/publications endpoint - update orderby description

### DIFF
--- a/publicationiq.json
+++ b/publicationiq.json
@@ -1454,7 +1454,7 @@
                           },
                           "resourceTypes": {
                             "type": "string",
-                            "description": "Resource Type.  Valid values are all, journal, newsletter, report, proceedings, website, newspaper, unspecified, book, bookseries, database, thesisdissertation, streamingaudio, streamingvideo, and audiobook."							
+                            "description": "Resource Type.  Valid values are all, journal, newsletter, report, proceedings, website, newspaper, unspecified, book, bookseries, database, thesisdissertation, streamingaudio, streamingvideo, and audiobook."
                           }
                         }
                       }
@@ -4946,7 +4946,7 @@
             "type": "string",
             "in": "query",
             "name": "orderby",
-            "description": "Order in which the publications will be returned. e.g. 'RELEVANCE'",
+            "description": "Order in which the publications will be returned. e.g. 'RELEVANCE'. Note that orderby will always be treated as 'TITLENAME' when the search term is blank.",
             "required": true,
             "enum": [
               "RELEVANCE",


### PR DESCRIPTION
https://rally1.rallydev.com/#/109021077464d/iterationstatus?detail=%2Fuserstory%2F809768739851%2Fdetails

- updating the description on the `orderby` parameter on the v1 /publications endpoint to the reflect the fact that the order will always be 'titlename' order, regardless of the orderby parameter passed in, if the search term is left blank on the request.

