### PR TITLE
US1321237 RMA-PFAPI/PubIQ: Update to return package category facets on response

### DIFF
--- a/publicationiq.json
+++ b/publicationiq.json
@@ -5371,6 +5371,17 @@
             "true",
             "false"
           ]
+        },
+        {
+          "name": "categoryfacet",
+          "in": "query",
+          "description": "Filters package search results by given categories. Accepts category id or name. If multiple categories are given, packages assigned to any of the given categories will be returned. Example: 4672.",
+          "required": false,
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "collectionFormat": "multi"
         }
       ],
       "get": {
@@ -6431,6 +6442,56 @@
         }
       }
     },
+    "packageFreeAccessFacet": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Count",
+          "example": 15
+        },
+        "name": {
+          "type": "boolean",
+          "description": "Indicates whether the given facet count is the count of free access packages or non free access packages",
+          "example": false
+        }
+      }
+    },
+    "categoryFacet": {
+      "type": "object",
+      "properties": {
+        "parentId": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The ID of the parent caregory",
+          "example": 4604
+        },
+        "id": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The ID of the category",
+          "example": 5061
+        },
+        "count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Count",
+          "example": 15
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the category",
+          "example": "Science collection"
+        },
+        "rank": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The rank of the category",
+          "example": 2
+        }
+      }
+    },
     "HSMPackageFacets":{
       "type": "object",
       "properties": {
@@ -6438,6 +6499,18 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/HSMPackageFacet"
+          }
+        },
+        "packageFreeAccessFacets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/packageFreeAccessFacet"
+          }
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/categoryFacet"
           }
         }
       }

--- a/publicationiq.json
+++ b/publicationiq.json
@@ -821,8 +821,8 @@
                 },
                 "peerReviewed": {
                   "type": "boolean",
-                  "description": "Title Description",
-                  "example": "Description Test."
+                  "description": "Indicates if the title is peer reviewed or not",
+                  "example": false
                 },
                 "publisherName": {
                   "type": "string",
@@ -837,7 +837,7 @@
                       "id": {
                         "type": "string",
                         "description": "Identifier Value",
-                        "example": 1
+                        "example": "1"
                       },
                       "source": {
                         "type": "string",
@@ -1042,7 +1042,7 @@
                           "embargoValue": {
                             "type": "integer",
                             "description": "The embargo value (number of embargoUnits).  A Null value means there is no embargo.",
-                            "example": "1"
+                            "example": 1
                           }
                         }
                       },
@@ -1064,7 +1064,7 @@
                           "embargoValue": {
                             "type": "integer",
                             "description": "The embargo value (number of embargoUnits).  A Null value means there is no embargo.",
-                            "example": "1"
+                            "example": 1
                           }
                         }
                       },
@@ -1147,7 +1147,7 @@
                               "type": "integer",
                               "format": "int64",
                               "description": "Unique identifier for the note",
-                              "example": "309"
+                              "example": 309
                             },
                             "custId": {
                               "type": "integer",
@@ -1217,7 +1217,7 @@
                               "type": "integer",
                               "format": "int64",
                               "description": "ID",
-                              "example": "a123"
+                              "example": 123
                             },
                             "label": {
                               "type": "string",
@@ -1256,7 +1256,7 @@
                         "type": "integer",
                         "format": "int64",
                         "description": "Customer ID",
-                        "example": "1123"
+                        "example": 1123
                       },
                       "displayName": {
                         "type": "string",
@@ -1409,7 +1409,7 @@
                     "items": {
                       "type": "string"
                     },
-                    "example": "Faculty, Student, Staff and Walk-Ins"
+                    "example": ["Faculty, Student, Staff and Walk-Ins"]
                   },
                   "weight": {
                     "type": "integer",
@@ -5996,7 +5996,7 @@
                 "items": {
                   "type": "string"
                 },
-                "example": "Faculty, Student, Staff and Walk-Ins"
+                "example": ["Faculty, Student, Staff and Walk-Ins"]
               },
               "weight": {
                 "type": "integer",


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related feature or story. -->
https://rally1.rallydev.com/#/109021077464d/iterationstatus?detail=%2Fuserstory%2F811524139753%2Fdetails

- PFAPI/PublicationsIQ now supports one or more `categoryfacet` query parameters being passed on the v1 package search endpoint. This can be the name or the id of the category
- PFAPI/PublicationsIQ now returns category facets on the v1 package search endpoint response. 
- PFAPI/PublicationsIQ now returns package free access facets on the v1 package search endpoint response.
- Fixed a few errors reported by Stoplight where the response examples did not match the specified types.
# Type of Change

- [x] Changes to an existing endpoint
- [ ] New endpoint(s)
- [ ] Documentation only

# Checklist

- [x] My changes are not on the main branch.
- [x] Any changes from the main branch of the remote repository have been incorporated into my PR branch.
- [x] I have added an example and description for each new parameter.
- [x] I have added an example and description for each new response element.
- [x] I have verified that the verb, url, and parameters for added or changed endpoints are correct.

# Testing Application Used

<!-- Please run your specification changes through a testing application. Please note the testing application that you used below. -->

- [x] Swagger UI
- [ ] Readme Reference
- [x] Stoplight
